### PR TITLE
Adds new API to add multiple attachments at once

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -20,6 +20,7 @@
 package net.rcarz.jiraclient;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
@@ -384,6 +385,57 @@ public class Issue extends Resource {
         public List<Issue> issues = null;
     }
 
+    public static final class NewAttachment {
+
+        private final String filename;
+        private final Object content;
+
+        public NewAttachment(File content) {
+            this(content.getName(), content);
+        }
+
+        public NewAttachment(String filename, File content) {
+            this.filename = requireFilename(filename);
+            this.content = requireContent(content);
+        }
+
+        public NewAttachment(String filename, InputStream content) {
+            this.filename = requireFilename(filename);
+            this.content = requireContent(content);
+        }
+
+        public NewAttachment(String filename, byte[] content) {
+            this.filename = requireFilename(filename);
+            this.content = requireContent(content);
+        }
+
+        String getFilename() {
+            return filename;
+        }
+
+        Object getContent() {
+            return content;
+        }
+
+        private static String requireFilename(String filename) {
+            if (filename == null) {
+                throw new NullPointerException("filename may not be null");
+            }
+            if (filename.length() == 0) {
+                throw new IllegalArgumentException("filename may not be empty");
+            }
+            return filename;
+        }
+
+        private static Object requireContent(Object content) {
+            if (content == null) {
+                throw new NullPointerException("content may not be null");
+            }
+            return content;
+        }
+
+    }
+
     private String key = null;
     private Map fields = null;
 
@@ -565,11 +617,32 @@ public class Issue extends Resource {
      *
      * @param file java.io.File
      *
-     * @throws JiraException when the comment creation fails
+     * @throws JiraException when the attachment creation fails
      */
     public void addAttachment(File file) throws JiraException {
         try {
             restclient.post(getRestUri(key) + "/attachments", file);
+        } catch (Exception ex) {
+            throw new JiraException("Failed add attachment to issue " + key, ex);
+        }
+    }
+
+    /**
+     * Adds an attachments to this issue.
+     *
+     * @param attachments  the attachments to add
+     *
+     * @throws JiraException when the attachments creation fails
+     */
+    public void addAttachments(NewAttachment... attachments) throws JiraException {
+        if (attachments == null) {
+            throw new NullPointerException("attachments may not be null");
+        }
+        if (attachments.length == 0) {
+            return;
+        }
+        try {
+            restclient.post(getRestUri(key) + "/attachments", attachments);
         } catch (Exception ex) {
             throw new JiraException("Failed add attachment to issue " + key, ex);
         }


### PR DESCRIPTION
Added new API Issue#addAttachments(NewAttachment[]) to add multiple attachments at once. The new API allows also creating the attachments from byte arrays and InputStreams:

byte[] screenshot1 = ... 
InputStream screenshot2 = ... 
File logFile = ....
Issue issue = ....
issue.addAttachments(
    new NewAttachment("screenshot1.png", screenshot1),
    new NewAttachment("screenshot2.png", screenshot2),
    new NewAttachment(logFile));
