### PR TITLE
Deserialize full datetime when available

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Field.java
+++ b/src/main/java/net/rcarz/jiraclient/Field.java
@@ -504,8 +504,12 @@ public final class Field {
         if (value instanceof Date || value == null)
             return (Date)value;
 
+        String dateStr = value.toString();
         SimpleDateFormat df = new SimpleDateFormat(DATE_FORMAT);
-        return df.parse(value.toString(), new ParsePosition(0));
+        if (dateStr.length() > DATE_FORMAT.length()) {
+            df = new SimpleDateFormat(DATETIME_FORMAT);
+        }
+        return df.parse(dateStr, new ParsePosition(0));
     }
 
     /**


### PR DESCRIPTION
Hi Bob, great work, thank you for making it available to all.

We found a limitation in that we need to know the exact time that a state change happens.  The JIRA Rest interface is giving ChangeLog.created back as a full datetime stamp, but in deserialization it was being truncated to YYYY-MM-DD so I've said that if more characters are available then try for the full timestamp.

Best Wishes, Peter Williams