### PR TITLE
Enabling support for cascading select

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Field.java
+++ b/src/main/java/net/rcarz/jiraclient/Field.java
@@ -574,7 +574,9 @@ public final class Field {
      * Converts the given value to a JSON object.
      *
      * @param name Field name
-     * @param value New field value
+     * @param value New field value. If field's value validation against meta data is to be skipped then value's type
+     *              should
+     *              be {@link IgnoreMetadataCheck}.
      * @param editmeta Edit metadata JSON object
      *
      * @return a JSON-encoded field value
@@ -584,6 +586,13 @@ public final class Field {
      */
     public static Object toJson(String name, Object value, JSONObject editmeta)
         throws JiraException, UnsupportedOperationException {
+
+        if (value instanceof IgnoreMetadataCheck) {
+            boolean ignoreMetaDataCheck = ((IgnoreMetadataCheck)value).skipMetadataValidation();
+            if (ignoreMetaDataCheck) {
+                return value.toString();
+            }
+        }
 
         Meta m = getFieldMetadata(name, editmeta);
         if (m.type == null)

--- a/src/main/java/net/rcarz/jiraclient/IgnoreMetadataCheck.java
+++ b/src/main/java/net/rcarz/jiraclient/IgnoreMetadataCheck.java
@@ -1,0 +1,16 @@
+package net.rcarz.jiraclient;
+
+/**
+ * This interface represents the capabilities that any payload for a custom field should possess and wherein
+ * the schema validations associated with a custom field are to be skipped.
+ *
+ * A good example for this would be when attempting to set/edit a custom field whose type is a cascading select.
+ *
+ */
+public interface IgnoreMetadataCheck {
+    /**
+     *
+     * @return - <code>true</code> if meta data validation is to be skipped.
+     */
+    boolean skipMetadataValidation();
+}

--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -137,6 +137,19 @@ public class Issue extends Resource {
             fields.put(name, value);
             return this;
         }
+
+        /**
+         * Appends a field to the update action.
+         *
+         * @param name Name of the field
+         * @param value A {@link IgnoreMetadataCheck} object that represents New field value
+         *
+         * @return the current fluent update instance
+         */
+        public FluentCreate field(String name, IgnoreMetadataCheck value) {
+            fields.put(name, value);
+            return this;
+        }
     }
 
 
@@ -391,6 +404,19 @@ public class Issue extends Resource {
             return this;
         }
 
+        /**
+         * Appends a field to the update action.
+         *
+         * @param name Name of the field
+         * @param value A {@link IgnoreMetadataCheck} object that represents New field value
+         *
+         * @return the current fluent update instance
+         */
+        public FluentUpdate field(String name, IgnoreMetadataCheck value) {
+            fields.put(name, value);
+            return this;
+        }
+
         private FluentUpdate fieldOperation(String oper, String name, Object value) {
             if (!fieldOpers.containsKey(name))
                 fieldOpers.put(name, new ArrayList());
@@ -527,6 +553,20 @@ public class Issue extends Resource {
             fields.put(name, value);
             return this;
         }
+
+        /**
+         * Appends a field to the transition action.
+         *
+         * @param name Name of the field
+         * @param value A {@link IgnoreMetadataCheck} object that represents New field value
+         *
+         * @return the current fluent transition instance
+         */
+        public FluentTransition field(String name, IgnoreMetadataCheck value) {
+            fields.put(name, value);
+            return this;
+        }
+
     }
 
     /**

--- a/src/test/java/net/rcarz/jiraclient/FieldTest.java
+++ b/src/test/java/net/rcarz/jiraclient/FieldTest.java
@@ -1,0 +1,32 @@
+package net.rcarz.jiraclient;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FieldTest {
+    @Test
+    public void testToJson() throws JiraException {
+        String input = "Dummy Payload";
+        IgnoreMetadataCheck payload = new FakePayload(input);
+        String output = (String) Field.toJson("test", payload, Utils.getTestIssue());
+        assertEquals("should return input payload without any transformation", input, output);
+    }
+
+    public static class FakePayload implements IgnoreMetadataCheck {
+        private String payload;
+
+        public FakePayload(String payload) {
+            this.payload = payload;
+        }
+
+        public boolean skipMetadataValidation() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return payload;
+        }
+    }
+}


### PR DESCRIPTION
Fix for #126 #127 #129

Its noticed that for fields that are of type cascadingselect
Jira’s schema responds with its type as “array”.
This causes the current implementation to try and 
change the payload for the field as a JSONArray but
Jira fails to deserialize this at its end because it
is not expecting a payload of type array.

The catch here is to sometimes have the metadata validation
disabled and send the payload as constructed by the user
directly as is to Jira. This pull request attempts at enabling
this capability.
