### PR TITLE
Allow JiraClient to use a custom HttpClient, e.g. for proxying

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/JiraClient.java
+++ b/src/main/java/net/rcarz/jiraclient/JiraClient.java
@@ -50,7 +50,7 @@ public class JiraClient {
      * @throws JiraException 
      */
     public JiraClient(String uri) throws JiraException {
-        this(uri, null);
+        this(null, uri, null);
     }
 
     /**
@@ -61,12 +61,26 @@ public class JiraClient {
      * @throws JiraException 
      */
     public JiraClient(String uri, ICredentials creds) throws JiraException {
-    	PoolingClientConnectionManager connManager = new PoolingClientConnectionManager();
-        connManager.setDefaultMaxPerRoute(20);
-        connManager.setMaxTotal(40);
-        HttpClient httpclient = new DefaultHttpClient(connManager);
+    	this(null, uri, creds);
+    }
+    
+    /**
+     * Creates an authenticated JIRA client with custom HttpClient.
+     *
+     * @param httpClient Custom HttpClient to be used
+     * @param uri Base URI of the JIRA server
+     * @param creds Credentials to authenticate with
+     * @throws JiraException 
+     */
+    public JiraClient(HttpClient httpClient, String uri, ICredentials creds) throws JiraException {
+    	if (httpClient == null) {
+	    	PoolingClientConnectionManager connManager = new PoolingClientConnectionManager();
+	        connManager.setDefaultMaxPerRoute(20);
+	        connManager.setMaxTotal(40);
+	        httpClient = new DefaultHttpClient(connManager);
+    	}
 
-        restclient = new RestClient(httpclient, creds, URI.create(uri));
+        restclient = new RestClient(httpClient, creds, URI.create(uri));
 
         if (creds != null) {
             username = creds.getLogonName();


### PR DESCRIPTION
Hi Bob,

I recently stumbled across jira-client and started to use it in a project. I noticed that currently, one cannot pass in a custom HttpClient as required for situations where you have to use a proxy to reach a Jira instance; attached please find the change.

Thank you for your work on jira-client,
kind regards,

Michael