### PR TITLE
Made searches return an empty SearchResult instance instead of throwing an exception on no result.

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -595,7 +595,7 @@ public class Issue extends Resource {
 			// first call
 			if (currentPage == null) {
 				currentPage = getNextIssues().iterator();
-				if (currentPage == null) {
+				if (currentPage == null || !currentPage.hasNext()) {
 					return null;
 				} else {
 					return currentPage.next();

--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -658,6 +658,17 @@ public class Issue extends Resource {
     
     /**
      * Issue search results structure.
+     *
+     * The issues of the result can be retrived from this class in 2 ways.
+     *
+     * The first is to access the issues field directly. This is a list of Issue instances.
+     * Note however that this will only contain the issues fetched in the initial search,
+     * so its size will be the same as the max result value or below.
+     *
+     * The second way is to use the iterator methods. This will return an Iterator instance,
+     * that will iterate over every result of the search, even if there is more than the max
+     * result value. The price for this, is that the call to next has none determistic performence,
+     * as it sometimes need to fetch a new batch of issues from Jira.
      */
     public static class SearchResult {
         public int start = 0;

--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -705,7 +705,7 @@ public class Issue extends Resource {
          * 
          * @return All issues found.
          */
-        public IssueIterator iterator() {
+        public Iterator<Issue> iterator() {
         	return issueIterator;
         }
     }

--- a/src/test/java/net/rcarz/jiraclient/SearchTest.java
+++ b/src/test/java/net/rcarz/jiraclient/SearchTest.java
@@ -2,9 +2,13 @@ package net.rcarz.jiraclient;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.nio.channels.Pipe;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.*;
 
 public class SearchTest {
 
@@ -19,6 +23,51 @@ public class SearchTest {
     assertEquals("should return exactly 1 issue", 1, searchResult.issues.size());
     assertEquals("with key " + key, key, searchResult.issues.get(0).getKey());
     assertEquals("and resolution Fixed", "Fixed", searchResult.issues.get(0).getResolution().getName());
+  }
+
+  @Test
+  public void testEmptySearchGivesEmptyResult() throws JiraException {
+    final JiraClient jira = new JiraClient("https://jira.atlassian.com/", null);
+
+    //Valid jql query that will always yield no results.
+    final String q = "key = NotExisting-9999999 AND key = blah-8833772";
+    Issue.SearchResult searchResult = jira.searchIssues(q);
+
+    final String assertMsg = "Searches that yield no results, should return an empty "
+            + Issue.SearchResult.class.getSimpleName() + " instance";
+    assertTrue(assertMsg, searchResult.issues.isEmpty());
+    assertFalse(assertMsg, searchResult.issues.iterator().hasNext());
+    assertEquals(assertMsg, 0, searchResult.total);
+    assertEquals(assertMsg, 0, searchResult.start);
+  }
+
+  @Test
+  public void testSearchResultIteratorWithinMaxResultLimit() throws JiraException {
+    final JiraClient jira = new JiraClient("https://jira.atlassian.com/", null);
+    final int usedMax = 2;
+    //Will return everything from the public Jira for Jira
+    final Issue.SearchResult searchResult = jira.searchIssues("", usedMax);
+    final List<Issue> iterResults = new ArrayList<Issue>(usedMax);
+    final Iterator<Issue> iterator = searchResult.iterator();
+    for (int i = 0 ; i < usedMax ; i++) {
+      iterResults.add(iterator.next());
+    }
+    assertEquals(searchResult.issues, iterResults);
+  }
+
+  @Test
+  public void testIterateBeyondMaxResult() throws JiraException {
+    final JiraClient jira = new JiraClient("https://jira.atlassian.com/", null);
+
+    //Will return everything from the public Jira for Jira (at the time of writing 163697 issues).
+    final int usedMax = 2;
+    Issue.SearchResult searchResult = jira.searchIssues("", usedMax);
+    final Iterator<Issue> iterator = searchResult.iterator();
+    System.out.println(searchResult.issues);
+    for (int i = 0 ; i < 3 ; i++) {
+      //Running this 3 times without failing, ensures the it can fetch issues beyond the first fetch batch size, as the used max result is only 2.
+      iterator.next();
+    }
   }
 
   @Test


### PR DESCRIPTION
Plus two minor related changes

This fixes Issue 158 