### PR TITLE
Retries for null JSON content

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -632,22 +632,28 @@ public class Issue extends Resource {
             }
 
             JSON result = null;
+            int tryCount = 0;
 
-            try {
-                URI searchUri = createSearchURI(restclient, jql, includedFields,
-                        expandFields, maxResults, startAt);
-                result = restclient.get(searchUri);
-            } catch (Exception ex) {
-                throw new JiraException("Failed to search issues", ex);
+            while (result == null && tryCount++ <= 10) {
+                try {
+                    URI searchUri = createSearchURI(restclient, jql, includedFields,
+                            expandFields, maxResults, startAt);
+                    result = restclient.get(searchUri);
+                } catch (Exception ex) {
+                    throw new JiraException("Failed to search issues", ex);
+                }
+            }
+
+            if (result == null) {
+                throw new JiraException("JSON payload is null");
             }
 
             if (!(result instanceof JSONObject)) {
                 throw new JiraException("JSON payload is malformed");
             }
 
-            
             Map map = (Map) result;
-    
+
             this.startAt = Field.getInteger(map.get("startAt"));
             this.maxResults = Field.getInteger(map.get("maxResults"));
             this.total = Field.getInteger(map.get("total"));


### PR DESCRIPTION
When making multiple requests there is a problem where a response contains no JSON payload. This is different to no results, where there is minimal JSON payload.

This seems to happen when two requests are processed in parallel, but the second of the requests responds before the first. This is possibly within the org.apache.http.client.HttpClient or it could be from Jira (though that seems unlikely as HTTP 200 is returned.

This change is a workaround to retry the request (up to total 10 attempts) when the JSON response is null.