### PR TITLE
Fix typo in "Get Issue Watchers" API request [Issue #178]

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Watches.java
+++ b/src/main/java/net/rcarz/jiraclient/Watches.java
@@ -71,7 +71,7 @@ public class Watches extends Resource {
         JSON result = null;
 
         try {
-            result = restclient.get(getBaseUri() + "issue/" + issue + "/watches");
+            result = restclient.get(getBaseUri() + "issue/" + issue + "/watchers");
         } catch (Exception ex) {
             throw new JiraException("Failed to retrieve watches for issue " + issue, ex);
         }


### PR DESCRIPTION
According to the doc, "https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-getIssueWatchers", the correct v2 API request is "/watchers" not "/watches"
