### PR TITLE
Fix de date format to sprint from agile API

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Field.java
+++ b/src/main/java/net/rcarz/jiraclient/Field.java
@@ -19,8 +19,6 @@
 
 package net.rcarz.jiraclient;
 
-import java.lang.Iterable;
-import java.lang.UnsupportedOperationException;
 import java.sql.Timestamp;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
@@ -31,8 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
 import net.sf.json.JSONNull;
+import net.sf.json.JSONObject;
 
 /**
  * Utility functions for translating between JSON and fields.
@@ -151,7 +149,8 @@ public final class Field {
     public static final String TRANSITION_TO_STATUS = "to";
 
     public static final String DATE_FORMAT = "yyyy-MM-dd";
-    public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    public static final String DATETIME_FORMAT_ZTIMEZONE = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    public static final String DATETIME_FORMAT_XTIMEZONE = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
     private Field() { }
 
@@ -256,10 +255,34 @@ public final class Field {
      * @return a Date instance or null if d isn't a string
      */
     public static Date getDateTime(Object d) {
+    	return getDateTime(d, DATETIME_FORMAT_ZTIMEZONE);
+    }
+    
+    /**
+     * Gets a date with a time from the given object. The format date is 
+     * specific to sprint obj from agile api 
+     *
+     * @param d a string representation of a date
+     *
+     * @return a Date instance or null if d isn't a string
+     */
+    public static Date getDateTimeSprint(Object d) {
+        return getDateTime(d, DATETIME_FORMAT_XTIMEZONE);
+    }
+    
+    /**
+     * Gets a date with a time from the given object.
+     *
+     * @param d a string representation of a date
+     * @param pattern the pattern that to be used do parse de string
+     *
+     * @return a Date instance or null if d isn't a string
+     */
+    private static Date getDateTime(Object d, String pattern) {
         Date result = null;
 
         if (d instanceof String) {
-            SimpleDateFormat df = new SimpleDateFormat(DATETIME_FORMAT);
+            SimpleDateFormat df = new SimpleDateFormat(pattern);
             result = df.parse((String)d, new ParsePosition(0));
         }
 
@@ -573,7 +596,7 @@ public final class Field {
         String dateStr = value.toString();
         SimpleDateFormat df = new SimpleDateFormat(DATE_FORMAT);
         if (dateStr.length() > DATE_FORMAT.length()) {
-            df = new SimpleDateFormat(DATETIME_FORMAT);
+            df = new SimpleDateFormat(DATETIME_FORMAT_ZTIMEZONE);
         }
         return df.parse(dateStr, new ParsePosition(0));
     }
@@ -680,7 +703,7 @@ public final class Field {
             else if (!(value instanceof Timestamp))
                 throw new JiraException("Field '" + name + "' expects a Timestamp value");
 
-            SimpleDateFormat df = new SimpleDateFormat(DATETIME_FORMAT);
+            SimpleDateFormat df = new SimpleDateFormat(DATETIME_FORMAT_ZTIMEZONE);
             return df.format(value);
         } else if (m.type.equals("issuetype") || m.type.equals("priority") ||
                 m.type.equals("user") || m.type.equals("resolution")) {

--- a/src/main/java/net/rcarz/jiraclient/agile/Sprint.java
+++ b/src/main/java/net/rcarz/jiraclient/agile/Sprint.java
@@ -87,9 +87,9 @@ public class Sprint extends AgileResource {
         super.deserialize(json);
         state = Field.getString(json.get("state"));
         originBoardId = getLong(json.get("originBoardId"));
-        startDate = Field.getDateTime(json.get("startDate"));
-        endDate = Field.getDateTime(json.get("endDate"));
-        completeDate = Field.getDateTime(json.get("completeDate"));
+        startDate = Field.getDateTimeSprint(json.get("startDate"));
+        endDate = Field.getDateTimeSprint(json.get("endDate"));
+        completeDate = Field.getDateTimeSprint(json.get("completeDate"));
     }
 
     public String getState() {


### PR DESCRIPTION
For some reason, agile API in jira server 7.2.1, the object sprint is returning date time with ISO 8601 time zone, while other date time are working with RFC 822. This pull request fix that problem.
