### PR TITLE
Added headers info within the RestException class

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/RestClient.java
+++ b/src/main/java/net/rcarz/jiraclient/RestClient.java
@@ -19,16 +19,6 @@
 
 package net.rcarz.jiraclient;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
-
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
@@ -52,6 +42,16 @@ import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.ByteArrayBody;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.InputStreamBody;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
 
 /**
  * A simple REST client that speaks JSON.
@@ -160,7 +160,7 @@ public class RestClient {
         StatusLine sl = resp.getStatusLine();
 
         if (sl.getStatusCode() >= 300)
-            throw new RestException(sl.getReasonPhrase(), sl.getStatusCode(), result.toString());
+            throw new RestException(sl.getReasonPhrase(), sl.getStatusCode(), result.toString(), resp.getAllHeaders());
 
         return result.length() > 0 ? JSONSerializer.toJSON(result.toString()): null;
     }

--- a/src/main/java/net/rcarz/jiraclient/RestException.java
+++ b/src/main/java/net/rcarz/jiraclient/RestException.java
@@ -19,7 +19,7 @@
 
 package net.rcarz.jiraclient;
 
-import java.lang.Throwable;
+import org.apache.http.Header;
 
 /**
  * An exception for JIRA REST errors.
@@ -28,12 +28,14 @@ public class RestException extends Exception {
 
     private int status;
     private String result;
+    private Header[] headers;
 
-    public RestException(String msg, int status, String result) {
+    public RestException(String msg, int status, String result, Header[] headers) {
         super(msg);
 
         this.status = status;
         this.result = result;
+        this.headers = headers;
     }
 
     public int getHttpStatusCode() {
@@ -44,8 +46,11 @@ public class RestException extends Exception {
         return result;
     }
 
+    public Header[] getHeaders() {
+        return headers;
+    }
+
     public String getMessage() {
         return String.format("%s %s: %s", Integer.toString(status), super.getMessage(), result);
     }
 }
-

--- a/src/test/groovy/net/rcarz/jiraclient/agile/BoardTest.groovy
+++ b/src/test/groovy/net/rcarz/jiraclient/agile/BoardTest.groovy
@@ -39,7 +39,7 @@ class BoardTest extends AbstractResourceTest {
 
     @Test
     void "Given a RestClient, when calling getAll() and use doesn't have access, then throws an 401 error."() {
-        RestException unauthorized = new RestException("Do not have access", 401, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 401, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "board"))
                 .thenThrow(unauthorized)
@@ -62,7 +62,7 @@ class BoardTest extends AbstractResourceTest {
 
     @Test
     void "Given a RestClient, when calling getBoard(666), then throws an 404 error."() {
-        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "board/666"))
                 .thenThrow(unauthorized)

--- a/src/test/groovy/net/rcarz/jiraclient/agile/EpicTest.groovy
+++ b/src/test/groovy/net/rcarz/jiraclient/agile/EpicTest.groovy
@@ -37,7 +37,7 @@ class EpicTest extends AbstractResourceTest {
 
     @Test
     void "Given an invalid epic ID, when calling getEpic(666), then throws an 404 error."() {
-        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "epic/666"))
                 .thenThrow(unauthorized)

--- a/src/test/groovy/net/rcarz/jiraclient/agile/IssueTest.groovy
+++ b/src/test/groovy/net/rcarz/jiraclient/agile/IssueTest.groovy
@@ -32,7 +32,7 @@ class IssueTest extends AbstractResourceTest {
 
     @Test
     void "Given an invalid issue ID, when calling getIssue(666), then throws an 404 error."() {
-        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "issue/666"))
                 .thenThrow(unauthorized)
@@ -55,7 +55,7 @@ class IssueTest extends AbstractResourceTest {
 
     @Test
     void "Given an invalid issue Key, when calling getIssue('HSP-2'), then throws an 404 error."() {
-        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "issue/HSP-2"))
                 .thenThrow(unauthorized)

--- a/src/test/groovy/net/rcarz/jiraclient/agile/SprintTest.groovy
+++ b/src/test/groovy/net/rcarz/jiraclient/agile/SprintTest.groovy
@@ -39,7 +39,7 @@ class SprintTest extends AbstractResourceTest {
 
     @Test
     void "Given a RestClient, when calling getAll() and use doesn't have access, then throws an 401 error."() {
-        RestException unauthorized = new RestException("Do not have access", 401, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 401, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "board/" + JSONResources.SPRINT_ORIGIN_BOARD_ID + "/sprint"))
                 .thenThrow(unauthorized)
@@ -62,7 +62,7 @@ class SprintTest extends AbstractResourceTest {
 
     @Test
     void "Given a RestClient, when calling getSprint(666), then throws an 404 error."() {
-        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized")
+        RestException unauthorized = new RestException("Do not have access", 404, "Unauthorized", [])
         RestClient mockRestClient = "given a REST Client"()
         when(mockRestClient.get(AgileResource.RESOURCE_URI + "sprint/666"))
                 .thenThrow(unauthorized)


### PR DESCRIPTION
Hi!

At present, in my company [Continuum Security](https://github.com/continuumsecurity) we are using this library and we are very happy with the results. We want to help you to improve it and therefore we have created this PR.

I'll try to explain as well as I can the aim of this PR.

### Problem
Sometimes in Jira, after several consecutive failed log in attempts a CAPTCHA is "triggered". We can check this in the error response from JIRA, if there is an X-Seraph-LoginReason header with a a value of AUTHENTICATION_DENIED, this means the application rejected the login without even checking the password. This way to know the error is described in this link https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-basic-authentication

When this error happens, the library throws a RestException that contains the HTTP status code, and the body of the response, but not the headers.

I need to read the headers of the response to know if the error is because of several consecutive failed log in attempts and inform to the user with more precision about the error.

### Solution
I added a new field to the class RestException to store the headers of the response. I this way, I can check if the headers list contains the specific header X-Seraph-LoginReason:AUTHENTICATION_DENIED and therefore, inform to the user in a more specific way.

Regards,
viktorKhan
